### PR TITLE
adding -b command line option, Nobodytxtopt branch

### DIFF
--- a/archnews
+++ b/archnews
@@ -38,7 +38,9 @@ WRAP_SIZE = 100  # Zero for no wrap.
 COLORIZE_OUTPUT = True
 ORDER = True  # True = newest news last, False = newest news first
 NUM_NEWS = 3  # 0 for all
-
+#Glyons added 240717
+BODY_TEXT = True
+####
 
 # ************************************************************
 #  Output
@@ -90,6 +92,17 @@ class Out:
             Out.print = Out._white_print
 
 
+    @staticmethod
+    def setbody(body_text):
+        """Sets the default value for global variable BODY_TEXT based on args input glyons 240717"""
+        global BODY_TEXT
+        if body_text == True:
+              BODY_TEXT = True
+              return BODY_TEXT
+        else:
+              BODY_TEXT = False
+              return BODY_TEXT
+
 # ************************************************************
 #  HTML parser
 # ************************************************************
@@ -133,6 +146,7 @@ class TheParser(HTMLParser):
 
     def _append_raw(self, text):
         self.out += text
+
 
     def handle_starttag(self, tag, attrs):
         self._stack.append(tag)
@@ -257,7 +271,10 @@ class FeedEntry:
         except SyntaxError as err:
             text = str(err)
         text = text.strip()
-        Out.print('none', wrap_func(text))
+        #glyons 240717 check if -b called(BODY_TEXT will be false) if no print the body
+        global BODY_TEXT
+        if BODY_TEXT == True:
+            Out.print('none', wrap_func(text))
 
     def get_plain_description(self):
         """Returns description without tags."""
@@ -301,7 +318,6 @@ class FeedParser:
             description = FeedParser._get(item, 'description')
             time_formatted = FeedParser._convert_time(pub_date)
             items.append(FeedEntry(time_formatted, title, link, description))
-
         return items
 
 
@@ -409,6 +425,11 @@ When -u parameter is used, last time of check is stored inside file {}.
     parser.add_argument(
         '-c', '--color', help='do not print in color, default is colorized output',
         default=COLORIZE_OUTPUT, dest='colorize_output', action='store_false')
+
+    #glyons 240717
+    parser.add_argument(
+        '-b', '--body', help='do not print out body of text, just title',
+        default=BODY_TEXT, dest='body_text', action='store_false')
 
     parser.add_argument(
         '-i', '--stdin', help='read feed from stdin, do not fetch data from the Internet',
@@ -529,6 +550,9 @@ def main(args):
     Out.set(args.colorize_output)
     if args.grep:
         Out.highlight_word = args.grep
+
+    #glyons 270717 check for body text
+    Out.setbody(args.body_text)
 
     # Set default locale ('' is for the system locale, otherwise
     # e.g. 'cs_CZ.UTF-8' can be used).

--- a/archnews
+++ b/archnews
@@ -38,9 +38,6 @@ WRAP_SIZE = 100  # Zero for no wrap.
 COLORIZE_OUTPUT = True
 ORDER = True  # True = newest news last, False = newest news first
 NUM_NEWS = 3  # 0 for all
-#Glyons added 240717
-BODY_TEXT = True
-####
 
 # ************************************************************
 #  Output
@@ -56,9 +53,10 @@ class Out:
     SUPER_BLUE = '\033[1;34;48m'
     SUPER_WHITE = '\033[1;37;48m'
     NONE = '\033[0m'
-
     highlight_word = ''
-
+    #glyons 240717
+    BODY_TEXT = True
+    
     @staticmethod
     def _color_highlight(return_color, text):
         if Out.highlight_word:
@@ -94,14 +92,14 @@ class Out:
 
     @staticmethod
     def setbody(body_text):
-        """Sets the default value for global variable BODY_TEXT based on args input glyons 240717"""
-        global BODY_TEXT
+        """Sets the default value for gBODY_TEXT based on args input glyons 240717"""
+        
         if body_text == True:
-              BODY_TEXT = True
-              return BODY_TEXT
+              Out.BODY_TEXT = True
+              return True
         else:
-              BODY_TEXT = False
-              return BODY_TEXT
+              Out.BODY_TEXT  = False
+              return False
 
 # ************************************************************
 #  HTML parser
@@ -272,8 +270,7 @@ class FeedEntry:
             text = str(err)
         text = text.strip()
         #glyons 240717 check if -b called(BODY_TEXT will be false) if no print the body
-        global BODY_TEXT
-        if BODY_TEXT == True:
+        if Out.BODY_TEXT == True:
             Out.print('none', wrap_func(text))
 
     def get_plain_description(self):
@@ -429,7 +426,7 @@ When -u parameter is used, last time of check is stored inside file {}.
     #glyons 240717
     parser.add_argument(
         '-b', '--body', help='do not print out body of text, just title',
-        default=BODY_TEXT, dest='body_text', action='store_false')
+        default=Out.BODY_TEXT, dest='body_text', action='store_false')
 
     parser.add_argument(
         '-i', '--stdin', help='read feed from stdin, do not fetch data from the Internet',

--- a/archnews.1
+++ b/archnews.1
@@ -27,6 +27,9 @@ Display help.
 .IP "\fB\-w\fR WRAP_SIZE, \fB\-\-wrap\fR WRAP_SIZE"
 Set wrap length (in number of characters), zero for no wrap. Default is 100.
 
+.IP "\fB\-b\fR, \fB\-\-body\fR"
+Turn off body text output, just display date, link and title. Default is display everything.
+
 .IP "\fB\-c\fR, \fB\-\-color\fR"
 Turn off color output.
 


### PR DESCRIPTION
 Hi 

I have added a -b command line option which only prints link, title and date when set for less verbose quieter output. I set a class var and method called BODY_TEXT(default True) and a static method
called setbody in class Out. I  set it based on output of args input and check this in Out.print class
to display text body or not.

Same as previous closed pull request but I changed global variable to a class variable called BODY_TEXT as this is better code.

Regards